### PR TITLE
Fix env not creating

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: mask-align
 dependencies:
-  -          csvkit=1.0.7
+  -          csvkit=1
   -          cudatoolkit=10.2
   -          nltk=3.6.2
   -          numpy


### PR DESCRIPTION
I had an issue that said that the specified version of `csvkit` doesn't exist (maybe it was from `conda-forge`?). So I relaxed the version constraint.