### PR TITLE
Add missing shebang in executable files

### DIFF
--- a/scripts/calculate-threshold-and-em/calculate_optimal_threshold.py
+++ b/scripts/calculate-threshold-and-em/calculate_optimal_threshold.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import re
 import random

--- a/scripts/calculate-threshold-and-em/preprocess_anotated.py
+++ b/scripts/calculate-threshold-and-em/preprocess_anotated.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import random
 import re

--- a/scripts/calculate-threshold-and-em/process_answer_indexes.py
+++ b/scripts/calculate-threshold-and-em/process_answer_indexes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import re
 import random

--- a/thualign/bin/train.sh
+++ b/thualign/bin/train.sh
@@ -1,4 +1,4 @@
-# coding=utf-8
+#!/usr/bin/env bash
 # Copyright 2021-Present The THUAlign Authors
 
 CLI_DIR=$(cd "$(dirname "$0")" || exit; pwd)


### PR DESCRIPTION
Without this line, when executing a file (i.e., doing `./file`), the shell interpreter (e.g., Bash) wouldn't know with what program it needs to be run, so it would run them as binary files or sometimes as shell script files (instead of Python ones).